### PR TITLE
Bug Report: Permanent Lock of dispute_sink_balance USDC (Bounty #5)

### DIFF
--- a/VULNERABILITY_REPORT.md
+++ b/VULNERABILITY_REPORT.md
@@ -1,0 +1,68 @@
+# Vulnerability Report: Permanent Lock of Dispute Sink USDC (No Withdrawal Mechanism)
+
+## Summary
+
+In `market_app/contract.py`, the `dispute_sink_balance` state variable accumulates USDC from slashed dispute bonds but **has no withdrawal method**. Combined with the absence of a `DeleteApplication` handler, this permanently locks funds in the contract with no recovery path.
+
+## Vulnerability Detail
+
+When a dispute is resolved, a portion of the losing party's bond is routed to `dispute_sink_balance`:
+
+```python
+# contract.py line 726 (_settle_confirmed_dispute — loser is challenger)
+self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)
+
+# contract.py line 736 (_settle_overturned_dispute — loser is proposer)
+self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)
+
+# contract.py line 745 (_settle_cancelled_dispute — proposer bond fully slashed)
+self.dispute_sink_balance.value = self.dispute_sink_balance.value + self.proposer_bond_held.value
+```
+
+The variable is initialized to 0 in `create()` (line 864) and only ever incremented. A comprehensive search of the entire codebase confirms:
+
+1. **No `withdraw_dispute_sink()` method exists** — there is no ABI method that decrements `dispute_sink_balance` or sends the corresponding USDC to any address (treasury, admin, or otherwise).
+2. **No `DeleteApplication` handler exists** — the contract has no `@arc4.baremethod(allow_actions=["DeleteApplication"])`, so the AVM rejects any delete call. Even if deletion were possible, ASA (USDC) balances require explicit inner transactions to transfer before deletion — passive ALGO close-out does not apply to ASAs.
+3. **No admin override exists** — neither `market_admin`, `resolution_authority`, nor `creator` have any path to extract these funds.
+
+### Comparison with other balance types
+
+Every other tracked USDC balance has an explicit withdrawal path:
+
+| Balance Variable | Withdrawal Method | Access Control |
+|---|---|---|
+| `pool_balance` | `claim()`, `refund()`, `claim_lp_residual()` | Users, LPs |
+| `lp_fee_balance` | `withdraw_lp_fees()` | LPs |
+| `protocol_fee_balance` | `withdraw_protocol_fees()` | Anyone (→treasury) |
+| `resolution_budget_balance` | `reclaim_resolution_budget()` | Creator |
+| `proposer_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
+| `challenger_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
+| **`dispute_sink_balance`** | **❌ NONE** | **N/A** |
+
+## Impact
+
+**MEDIUM — Permanent fund lock.** USDC accumulates in the contract with no recovery.
+
+With `DEFAULT_DISPUTE_SINK_SHARE_BPS = 5000` (50%), half of every losing bond is permanently locked. For a market with a 1,000 USDC challenge bond and an overturned dispute in which the proposer had posted a 1,000 USDC bond:
+
+- `winner_bonus = floor(1000 * 5000 / 10000) = 500 USDC` → winner
+- `dispute_sink = 1000 - 500 = 500 USDC` → **permanently locked**
+
+Across many resolved markets, the cumulative locked amount grows without bound.
+
+## Recommendation
+
+Add a `withdraw_dispute_sink` method gated to an authorized role (e.g., `protocol_treasury` or `market_admin`):
+
+```python
+@arc4.abimethod()
+def withdraw_dispute_sink(self) -> None:
+    self._require_status_any2(UInt64(STATUS_RESOLVED), UInt64(STATUS_CANCELLED))
+    amount = self.dispute_sink_balance.value
+    self._require(amount > UInt64(0))
+    self.dispute_sink_balance.value = UInt64(0)
+    self._send_currency(Account(self.protocol_treasury.value), amount)
+    arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(amount))
+```
+
+Alternatively, fold the sink share into `protocol_fee_balance` during settlement so it is withdrawn via the existing `withdraw_protocol_fees()` path.

--- a/smart_contracts/market_app/contract.py
+++ b/smart_contracts/market_app/contract.py
@@ -147,6 +147,7 @@ PENDING_PAYOUT_BOX_MBR = 2_500 + 400 * (3 + 32 + 8)  # 19_700
 # arc4.emit("Cancel()")
 # arc4.emit("Refund(uint64)")
 # arc4.emit("WithdrawPendingPayouts(uint64)")
+# arc4.emit("WithdrawDisputeSink(uint64)")
 # arc4.emit("CommentPosted(string)")
 
 
@@ -1366,6 +1367,15 @@ class QuestionMarket(ARC4Contract):
         self.protocol_fee_balance.value = UInt64(0)
         self._send_currency(Account(self.protocol_treasury.value), amount)
         arc4.emit("WithdrawFees(uint64)", arc4.UInt64(amount))
+
+    @arc4.abimethod()
+    def withdraw_dispute_sink(self) -> None:
+        """Withdraw accumulated dispute-sink balance to the configured protocol treasury."""
+        amount = self.dispute_sink_balance.value
+        self._require(amount > UInt64(0))
+        self.dispute_sink_balance.value = UInt64(0)
+        self._send_currency(Account(self.protocol_treasury.value), amount)
+        arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(amount))
 
     @arc4.abimethod()
     def refund(self, outcome_index: arc4.UInt64, shares: arc4.UInt64) -> None:

--- a/smart_contracts/market_app/contract.py
+++ b/smart_contracts/market_app/contract.py
@@ -147,7 +147,6 @@ PENDING_PAYOUT_BOX_MBR = 2_500 + 400 * (3 + 32 + 8)  # 19_700
 # arc4.emit("Cancel()")
 # arc4.emit("Refund(uint64)")
 # arc4.emit("WithdrawPendingPayouts(uint64)")
-# arc4.emit("WithdrawDisputeSink(uint64)")
 # arc4.emit("CommentPosted(string)")
 
 
@@ -1361,21 +1360,13 @@ class QuestionMarket(ARC4Contract):
 
     @arc4.abimethod()
     def withdraw_protocol_fees(self) -> None:
-        """Withdraw accumulated protocol fees to the configured protocol treasury."""
-        amount = self.protocol_fee_balance.value
+        """Withdraw accumulated protocol fees and dispute-sink balance to the configured protocol treasury."""
+        amount = self.protocol_fee_balance.value + self.dispute_sink_balance.value
         self._require(amount > UInt64(0))
         self.protocol_fee_balance.value = UInt64(0)
-        self._send_currency(Account(self.protocol_treasury.value), amount)
-        arc4.emit("WithdrawFees(uint64)", arc4.UInt64(amount))
-
-    @arc4.abimethod()
-    def withdraw_dispute_sink(self) -> None:
-        """Withdraw accumulated dispute-sink balance to the configured protocol treasury."""
-        amount = self.dispute_sink_balance.value
-        self._require(amount > UInt64(0))
         self.dispute_sink_balance.value = UInt64(0)
         self._send_currency(Account(self.protocol_treasury.value), amount)
-        arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(amount))
+        arc4.emit("WithdrawFees(uint64)", arc4.UInt64(amount))
 
     @arc4.abimethod()
     def refund(self, outcome_index: arc4.UInt64, shares: arc4.UInt64) -> None:

--- a/tests/test_market_app_contract_runtime.py
+++ b/tests/test_market_app_contract_runtime.py
@@ -2154,3 +2154,45 @@ def test_withdraw_protocol_fees_sends_to_stored_treasury(disable_arc4_emit) -> N
         assert transfers[0].asset_receiver == Account(treasury)
         assert int(transfers[0].asset_amount) == accrued_protocol_fees
         assert usdc_balance(context, attacker) == attacker_before
+
+
+def test_withdraw_protocol_fees_drains_dispute_sink_to_treasury(disable_arc4_emit) -> None:
+    creator = make_address()
+    resolver = make_address()
+    challenger = make_address()
+    treasury = make_address()
+    attacker = make_address()
+
+    with algopy_testing_context() as context:
+        contract = QuestionMarket()
+        create_contract(context, contract, creator=creator, resolver=resolver, protocol_treasury=treasury)
+        register_outcome_asas(context, contract, creator)
+        ensure_blueprint_cid(contract)
+        seed_usdc_balance(context, treasury, 0)
+
+        payment = make_usdc_payment(context, contract, creator, 200_000_000)
+        call_as(context, creator, contract.bootstrap, arc4.UInt64(200_000_000), payment, latest_timestamp=1)
+        call_as(context, creator, contract.trigger_resolution, latest_timestamp=10_000)
+
+        propose_payment = make_usdc_payment(context, contract, resolver, 10_000_000)
+        call_as(context, resolver, contract.propose_resolution, arc4.UInt64(0), arc4.DynamicBytes(b"e" * 32), propose_payment, latest_timestamp=10_001)
+        challenge_payment = make_usdc_payment(context, contract, challenger, required_bond(contract, proposal=False))
+        call_as(
+            context, challenger, contract.challenge_resolution,
+            challenge_payment, arc4.UInt64(1), arc4.DynamicBytes(b"c" * 32),
+            latest_timestamp=10_002,
+        )
+        call_as(context, resolver, contract.creator_resolve_dispute, arc4.UInt64(0), arc4.DynamicBytes(b"r" * 32), latest_timestamp=10_003)
+
+        sink_accrued = int(contract.dispute_sink_balance.value)
+        protocol_fees_before = int(contract.protocol_fee_balance.value)
+        assert sink_accrued > 0
+
+        call_as(context, attacker, contract.withdraw_protocol_fees, latest_timestamp=10_004)
+
+        transfers = last_inner_asset_transfers(context)
+        assert int(contract.dispute_sink_balance.value) == 0
+        assert int(contract.protocol_fee_balance.value) == 0
+        assert len(transfers) == 1
+        assert transfers[0].asset_receiver == Account(treasury)
+        assert int(transfers[0].asset_amount) == sink_accrued + protocol_fees_before


### PR DESCRIPTION
# Vulnerability Report: Permanent Lock of Dispute Sink USDC (No Withdrawal Mechanism)

## Summary

In `market_app/contract.py`, the `dispute_sink_balance` state variable accumulates USDC from slashed dispute bonds but **has no withdrawal method**. Combined with the absence of a `DeleteApplication` handler, this permanently locks funds in the contract with no recovery path.

## Vulnerability Detail

When a dispute is resolved, a portion of the losing party's bond is routed to `dispute_sink_balance`:

```python
# contract.py line 726 (_settle_confirmed_dispute — loser is challenger)
self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)

# contract.py line 736 (_settle_overturned_dispute — loser is proposer)
self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)

# contract.py line 745 (_settle_cancelled_dispute — proposer bond fully slashed)
self.dispute_sink_balance.value = self.dispute_sink_balance.value + self.proposer_bond_held.value
```

The variable is initialized to 0 in `create()` (line 864) and only ever incremented. A comprehensive search of the entire codebase confirms:

1. **No `withdraw_dispute_sink()` method exists** — there is no ABI method that decrements `dispute_sink_balance` or sends the corresponding USDC to any address (treasury, admin, or otherwise).
2. **No `DeleteApplication` handler exists** — the contract has no `@arc4.baremethod(allow_actions=["DeleteApplication"])`, so the AVM rejects any delete call. Even if deletion were possible, ASA (USDC) balances require explicit inner transactions to transfer before deletion — passive ALGO close-out does not apply to ASAs.
3. **No admin override exists** — neither `market_admin`, `resolution_authority`, nor `creator` have any path to extract these funds.

### Comparison with other balance types

Every other tracked USDC balance has an explicit withdrawal path:

| Balance Variable | Withdrawal Method | Access Control |
|---|---|---|
| `pool_balance` | `claim()`, `refund()`, `claim_lp_residual()` | Users, LPs |
| `lp_fee_balance` | `withdraw_lp_fees()` | LPs |
| `protocol_fee_balance` | `withdraw_protocol_fees()` | Anyone (→treasury) |
| `resolution_budget_balance` | `reclaim_resolution_budget()` | Creator |
| `proposer_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
| `challenger_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
| **`dispute_sink_balance`** | **❌ NONE** | **N/A** |

## Impact

**MEDIUM — Permanent fund lock.** USDC accumulates in the contract with no recovery.

With `DEFAULT_DISPUTE_SINK_SHARE_BPS = 5000` (50%), half of every losing bond is permanently locked. For a market with a 1,000 USDC challenge bond and an overturned dispute in which the proposer had posted a 1,000 USDC bond:

- `winner_bonus = floor(1000 * 5000 / 10000) = 500 USDC` → winner
- `dispute_sink = 1000 - 500 = 500 USDC` → **permanently locked**

Across many resolved markets, the cumulative locked amount grows without bound.

## Recommendation

Add a `withdraw_dispute_sink` method gated to an authorized role (e.g., `protocol_treasury` or `market_admin`):

```python
@arc4.abimethod()
def withdraw_dispute_sink(self) -> None:
    self._require_status_any2(UInt64(STATUS_RESOLVED), UInt64(STATUS_CANCELLED))
    amount = self.dispute_sink_balance.value
    self._require(amount > UInt64(0))
    self.dispute_sink_balance.value = UInt64(0)
    self._send_currency(Account(self.protocol_treasury.value), amount)
    arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(amount))
```

Alternatively, fold the sink share into `protocol_fee_balance` during settlement so it is withdrawn via the existing `withdraw_protocol_fees()` path.

Closes #5 
