### PR TITLE
bug: LP Fee Rounding Dust — Permanent Lock

### DIFF
--- a/VULNERABILITY_REPORT_LP_FEE_DUST.md
+++ b/VULNERABILITY_REPORT_LP_FEE_DUST.md
@@ -1,0 +1,79 @@
+# Vulnerability Report: LP Fee Rounding Dust — Permanent Lock
+
+## Summary
+
+In `market_app/contract.py`, double floor-division rounding in `_distribute_lp_fee()` and `_settle_lp_fees()` causes micro-amounts of LP fees to accumulate permanently in `lp_fee_balance` with no LP able to claim them. The gap between tracked `lp_fee_balance` and the sum of all LP entitlements grows monotonically with each trade.
+
+## Vulnerability Detail
+
+### Root Cause 1: `_distribute_lp_fee()` (line 620–624)
+
+When LP fees are distributed, the per-share increment is computed with floor division:
+
+```python
+increment = lmsr_mul_div_floor(fee_amount, UInt64(SCALE), self.lp_shares_total.value)
+self.cumulative_fee_per_share.value += increment
+```
+
+The dust lost per call is:
+```
+dust₁ = fee_amount − (increment × lp_shares_total / SCALE)
+      = (fee_amount × SCALE) % lp_shares_total  /  (SCALE / lp_shares_total)
+```
+
+When `fee_amount × SCALE < lp_shares_total`, the increment rounds to **zero** and the **entire fee** is lost to dust.
+
+### Root Cause 2: `_settle_lp_fees()` (line 509–520)
+
+When each LP settles their accrued fees, another floor division occurs:
+
+```python
+accrued = lmsr_mul_div_floor(delta, shares, UInt64(SCALE))
+```
+
+Even when the increment from step 1 is non-zero, individual LP entitlements lose additional dust from this second rounding.
+
+### Compound Effect
+
+Both rounding losses accumulate in `lp_fee_balance` but no LP's claimable amount includes them. The locked dust grows monotonically and is **permanently irrecoverable**.
+
+## Impact
+
+**LOW — Permanent lock of LP fees.**
+
+The severity depends on the ratio of `fee_per_trade` to `lp_shares_total`:
+
+| Scenario | Fee/Trade | LP Pool | Trades | Total Fees | Dust Locked | % Locked |
+|----------|-----------|---------|--------|-----------|-------------|----------|
+| Worst case | 0.001 USDC | $10K | 10,000 | $10.00 | **$10.00** | 100% |
+| Moderate | 0.10 USDC | $1K (3 LPs) | 1,000 | $100.00 | $0.001 | 0.001% |
+| Best case | 1.00 USDC | $1K (2 equal) | 500 | $500.00 | $0.00 | 0% |
+| Extreme grind | 0.000007 USDC | ~$8 (prime) | 50,000 | $0.35 | **$0.35** | 100% |
+
+In markets with many small trades and large liquidity pools, the locked amount can equal 100% of LP fees.
+
+## PoC
+
+See [`audit/bug3_lp_fee_dust_lock.py`](audit/bug3_lp_fee_dust_lock.py) — a standalone Python simulation that reproduces all four scenarios above using the project's own `lmsr_math` module.
+
+Run:
+```bash
+python3 audit/bug3_lp_fee_dust_lock.py
+```
+
+## Recommendation
+
+Accumulate rounding remainders in a dedicated dust variable and periodically redistribute, or switch the fee-per-share accumulator to a higher-precision fixed-point (e.g., `SCALE²`):
+
+```python
+# Option A: Track remainders explicitly
+remainder = (fee_amount * SCALE) % self.lp_shares_total.value
+self.lp_fee_dust_remainder.value += remainder
+# When remainder >= lp_shares_total, flush 1 unit into cumulative
+
+# Option B: Higher-precision accumulator (simplest)
+# Use SCALE * SCALE for cumulative_fee_per_share to reduce dust by ~10^6x
+increment = lmsr_mul_div_floor(fee_amount, UInt64(SCALE * SCALE), self.lp_shares_total.value)
+```
+
+Either approach reduces the locked dust by orders of magnitude without changing the external API.

--- a/audit/bug3_lp_fee_dust_lock.py
+++ b/audit/bug3_lp_fee_dust_lock.py
@@ -1,0 +1,209 @@
+"""
+Proof-of-Concept: LP Fee Rounding Dust — Permanent Lock
+
+Demonstrates that floor-division rounding in _distribute_lp_fee() and
+_settle_lp_fees() causes micro-dust to accumulate permanently in
+lp_fee_balance with no LP able to claim it.
+
+Root cause:
+  1. _distribute_lp_fee: increment = floor(fee * SCALE / lp_shares_total)
+     → loses (fee * SCALE) % lp_shares_total
+  2. _settle_lp_fees:    accrued = floor(delta * shares / SCALE)
+     → loses (delta * shares) % SCALE
+
+The gap between lp_fee_balance and sum-of-all-LP-entitlements grows
+monotonically with each trade. This dust is permanently locked.
+
+Impact:
+  Permanent lock of LP fees. Cumulative over market lifetime.
+
+Reference:
+  - contract.py: _distribute_lp_fee() (line 620-624)
+  - contract.py: _settle_lp_fees() (line 509-520)
+
+Author: y4motion (Triarchy bounty audit)
+"""
+import sys
+import os
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from smart_contracts.lmsr_math import SCALE
+
+# ──────────────────────────────────────────────────────
+# Simulate the fee distribution math from contract.py
+# ──────────────────────────────────────────────────────
+
+def mul_div_floor(a: int, b: int, denom: int) -> int:
+    """Mirrors _mul_div_floor from lmsr_math_avm.py."""
+    assert denom > 0
+    return (a * b) // denom
+
+
+def simulate_fee_dust_accumulation(
+    num_trades: int,
+    fee_per_trade: int,
+    lp_shares_total: int,
+    lp_holders: dict[str, int],  # name -> shares
+) -> dict:
+    """
+    Simulate N trades and track the gap between lp_fee_balance
+    and total claimable fees across all LPs.
+    """
+    cumulative_fee_per_share = 0
+    lp_fee_balance = 0
+    lp_snapshots = {name: 0 for name in lp_holders}
+    lp_accrued = {name: 0 for name in lp_holders}
+
+    for trade_idx in range(num_trades):
+        # === _distribute_lp_fee() ===
+        fee_amount = fee_per_trade
+        lp_fee_balance += fee_amount
+
+        if lp_shares_total > 0 and fee_amount > 0:
+            # Floor division: this is where dust is born
+            increment = mul_div_floor(fee_amount, SCALE, lp_shares_total)
+            cumulative_fee_per_share += increment
+
+        # === _settle_lp_fees() for each LP ===
+        for name, shares in lp_holders.items():
+            if shares == 0:
+                continue
+            snapshot = lp_snapshots[name]
+            if cumulative_fee_per_share > snapshot:
+                delta = cumulative_fee_per_share - snapshot
+                # Floor division: more dust lost
+                accrued = mul_div_floor(delta, shares, SCALE)
+                lp_accrued[name] += accrued
+            lp_snapshots[name] = cumulative_fee_per_share
+
+    total_claimable = sum(lp_accrued.values())
+    dust_locked = lp_fee_balance - total_claimable
+
+    return {
+        "num_trades": num_trades,
+        "fee_per_trade": fee_per_trade,
+        "lp_fee_balance": lp_fee_balance,
+        "total_claimable": total_claimable,
+        "dust_locked": dust_locked,
+        "dust_pct": (dust_locked / lp_fee_balance * 100) if lp_fee_balance > 0 else 0,
+        "per_lp": lp_accrued,
+    }
+
+
+def main():
+    print()
+    print("=" * 70)
+    print("  BUG 3: LP Fee Rounding Dust — Permanent Lock PoC")
+    print("=" * 70)
+    print()
+
+    # ────────────────────────────────────────────────
+    # Scenario 1: Small fees, large LP pool (worst case for dust)
+    # ────────────────────────────────────────────────
+    print("─" * 70)
+    print("  Scenario 1: Small fees ($0.001), large LP pool ($10K)")
+    print("─" * 70)
+    result = simulate_fee_dust_accumulation(
+        num_trades=10_000,
+        fee_per_trade=1_000,       # 0.001 USDC (1000 microUSDC)
+        lp_shares_total=10_000_000_000,  # ~$10K liquidity
+        lp_holders={
+            "creator": 5_000_000_000,    # 50%
+            "lp_alice": 3_000_000_000,   # 30%
+            "lp_bob": 2_000_000_000,     # 20%
+        },
+    )
+    print_result(result)
+
+    # ────────────────────────────────────────────────
+    # Scenario 2: Moderate fees, 3 LPs with uneven shares
+    # ────────────────────────────────────────────────
+    print("─" * 70)
+    print("  Scenario 2: Moderate fees ($0.10), 3 uneven LPs ($1K)")
+    print("─" * 70)
+    result = simulate_fee_dust_accumulation(
+        num_trades=1_000,
+        fee_per_trade=100_000,     # 0.10 USDC
+        lp_shares_total=1_000_000_000,
+        lp_holders={
+            "creator": 333_333_333,   # ~33.3%
+            "lp_alice": 333_333_333,  # ~33.3%
+            "lp_bob": 333_333_334,    # ~33.3%
+        },
+    )
+    print_result(result)
+
+    # ────────────────────────────────────────────────
+    # Scenario 3: Large fees, 2 LPs (minimal dust)
+    # ────────────────────────────────────────────────
+    print("─" * 70)
+    print("  Scenario 3: Large fees ($1.00), 2 equal LPs ($1K)")
+    print("─" * 70)
+    result = simulate_fee_dust_accumulation(
+        num_trades=500,
+        fee_per_trade=1_000_000,   # 1.00 USDC
+        lp_shares_total=1_000_000_000,
+        lp_holders={
+            "creator": 500_000_000,
+            "lp_alice": 500_000_000,
+        },
+    )
+    print_result(result)
+
+    # ────────────────────────────────────────────────
+    # Scenario 4: Extreme case — prime-number LP shares
+    # ────────────────────────────────────────────────
+    print("─" * 70)
+    print("  Scenario 4: Extreme — prime LP shares, tiny fees, 50K trades")
+    print("─" * 70)
+    result = simulate_fee_dust_accumulation(
+        num_trades=50_000,
+        fee_per_trade=7,           # 0.000007 USDC (7 microUSDC)
+        lp_shares_total=7_919_999,  # prime-ish number
+        lp_holders={
+            "creator": 3_000_001,
+            "lp_alice": 2_919_999,
+            "lp_bob": 1_999_999,
+        },
+    )
+    print_result(result)
+
+    # ────────────────────────────────────────────────
+    # Verdict
+    # ────────────────────────────────────────────────
+    print("=" * 70)
+    print("  VERDICT")
+    print("=" * 70)
+    print()
+    print("  _distribute_lp_fee() uses floor division to compute the per-share")
+    print("  fee increment. _settle_lp_fees() again uses floor division when")
+    print("  computing each LP's accrued fees. Both rounding steps lose dust.")
+    print()
+    print("  The gap between lp_fee_balance and sum-of-all-LP-entitlements")
+    print("  grows monotonically and is permanently locked in the contract.")
+    print()
+    print("  Impact: Permanent lock of LP fees. In worst-case scenarios")
+    print("  (small fees, many trades, uneven LP shares), the locked amount")
+    print("  can reach meaningful fractions of total fees.")
+    print()
+    print("  Qualifies under bounty scope: 'affect user funds — permanent lock'")
+    print()
+
+
+def print_result(r: dict):
+    print(f"  Trades:         {r['num_trades']:>12,}")
+    print(f"  Fee/trade:      {r['fee_per_trade']:>12,} μUSDC ({r['fee_per_trade']/1e6:.6f} USDC)")
+    print(f"  Total fees:     {r['lp_fee_balance']:>12,} μUSDC ({r['lp_fee_balance']/1e6:.4f} USDC)")
+    print(f"  Total claimable:{r['total_claimable']:>12,} μUSDC")
+    print(f"  DUST LOCKED:    {r['dust_locked']:>12,} μUSDC ({r['dust_locked']/1e6:.6f} USDC)")
+    print(f"  Dust %:         {r['dust_pct']:>11.4f}%")
+    print(f"  Per-LP claims:")
+    for name, amount in r['per_lp'].items():
+        print(f"    {name:15s}: {amount:>12,} μUSDC")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Floor-division rounding in `_distribute_lp_fee()` and `_settle_lp_fees()` causes micro-amounts of LP fees to accumulate permanently in `lp_fee_balance` with no LP able to claim them.

## Root Cause

1. **`_distribute_lp_fee()` (line 620–624):** `increment = floor(fee × SCALE / lp_shares_total)` loses dust when `fee × SCALE < lp_shares_total` — the increment rounds to **zero** and the entire fee is lost.

2. **`_settle_lp_fees()` (line 509–520):** `accrued = floor(delta × shares / SCALE)` loses additional dust per LP.

## Impact

**Permanent lock of LP fees.** The gap between `lp_fee_balance` and sum-of-all-LP-entitlements grows monotonically.

| Scenario | Fee/Trade | LP Pool | Trades | Total Fees | Dust Locked | % |
|----------|-----------|---------|--------|-----------|-------------|---|
| Worst case | 0.001 USDC | $10K | 10,000 | $10.00 | **$10.00** | 100% |
| Moderate | 0.10 USDC | $1K | 1,000 | $100.00 | $0.001 | 0.001% |
| Extreme grind | 7 μUSDC | ~$8 | 50,000 | $0.35 | **$0.35** | 100% |

## PoC

```bash
python3 audit/bug3_lp_fee_dust_lock.py
```

Full report: [VULNERABILITY_REPORT_LP_FEE_DUST.md](VULNERABILITY_REPORT_LP_FEE_DUST.md)

## Recommendation

Accumulate remainders in a dust variable and periodically flush, or increase the accumulator precision to `SCALE²`.

Relates to #10