### PR TITLE
Security: UInt64 overflow in LP residual weight permanently locks funds above ~$10k LP

### DIFF
--- a/VULNERABILITY_REPORT.md
+++ b/VULNERABILITY_REPORT.md
@@ -1,68 +1,122 @@
-# Vulnerability Report: Permanent Lock of Dispute Sink USDC (No Withdrawal Mechanism)
+# Security Audit: Arithmetic Overflow in LP Residual Weight + Missing Inventory Invariant
 
 ## Summary
 
-In `market_app/contract.py`, the `dispute_sink_balance` state variable accumulates USDC from slashed dispute bonds but **has no withdrawal method**. Combined with the absence of a `DeleteApplication` handler, this permanently locks funds in the contract with no recovery path.
+Two issues found during manual review of `market_app/contract.py`:
 
-## Vulnerability Detail
+1. **UInt64 overflow in `_entry_weighted_sum_checked`** — `_total_residual_weight()` reverts when `lp_shares_total × settlement_timestamp > 2⁶⁴`, permanently blocking `claim_lp_residual()` for all LPs. Affects markets with total LP contribution above ~$10,376 USDC at current timestamps.
+2. **Missing on-chain invariant** — the reference model asserts `q[i] >= total_user_shares[i]` but the contract omits this check, removing a defense-in-depth layer.
 
-When a dispute is resolved, a portion of the losing party's bond is routed to `dispute_sink_balance`:
+---
 
-```python
-# contract.py line 726 (_settle_confirmed_dispute — loser is challenger)
-self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)
+## Finding 1: UInt64 Overflow in LP Residual Weight Calculation
 
-# contract.py line 736 (_settle_overturned_dispute — loser is proposer)
-self.dispute_sink_balance.value = self.dispute_sink_balance.value + (losing_bond - winner_bonus)
+### Severity: Medium (scaling concern — permanent fund lock above realistic threshold)
 
-# contract.py line 745 (_settle_cancelled_dispute — proposer bond fully slashed)
-self.dispute_sink_balance.value = self.dispute_sink_balance.value + self.proposer_bond_held.value
-```
+### Vulnerability Detail
 
-The variable is initialized to 0 in `create()` (line 864) and only ever incremented. A comprehensive search of the entire codebase confirms:
-
-1. **No `withdraw_dispute_sink()` method exists** — there is no ABI method that decrements `dispute_sink_balance` or sends the corresponding USDC to any address (treasury, admin, or otherwise).
-2. **No `DeleteApplication` handler exists** — the contract has no `@arc4.baremethod(allow_actions=["DeleteApplication"])`, so the AVM rejects any delete call. Even if deletion were possible, ASA (USDC) balances require explicit inner transactions to transfer before deletion — passive ALGO close-out does not apply to ASAs.
-3. **No admin override exists** — neither `market_admin`, `resolution_authority`, nor `creator` have any path to extract these funds.
-
-### Comparison with other balance types
-
-Every other tracked USDC balance has an explicit withdrawal path:
-
-| Balance Variable | Withdrawal Method | Access Control |
-|---|---|---|
-| `pool_balance` | `claim()`, `refund()`, `claim_lp_residual()` | Users, LPs |
-| `lp_fee_balance` | `withdraw_lp_fees()` | LPs |
-| `protocol_fee_balance` | `withdraw_protocol_fees()` | Anyone (→treasury) |
-| `resolution_budget_balance` | `reclaim_resolution_budget()` | Creator |
-| `proposer_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
-| `challenger_bond_held` | `_credit_pending_payout()` → `withdraw_pending_payouts()` | Winner |
-| **`dispute_sink_balance`** | **❌ NONE** | **N/A** |
-
-## Impact
-
-**MEDIUM — Permanent fund lock.** USDC accumulates in the contract with no recovery.
-
-With `DEFAULT_DISPUTE_SINK_SHARE_BPS = 5000` (50%), half of every losing bond is permanently locked. For a market with a 1,000 USDC challenge bond and an overturned dispute in which the proposer had posted a 1,000 USDC bond:
-
-- `winner_bonus = floor(1000 * 5000 / 10000) = 500 USDC` → winner
-- `dispute_sink = 1000 - 500 = 500 USDC` → **permanently locked**
-
-Across many resolved markets, the cumulative locked amount grows without bound.
-
-## Recommendation
-
-Add a `withdraw_dispute_sink` method gated to an authorized role (e.g., `protocol_treasury` or `market_admin`):
+`_entry_weighted_sum_checked` (L587–590) computes `shares × timestamp` with a `mulw` overflow guard:
 
 ```python
-@arc4.abimethod()
-def withdraw_dispute_sink(self) -> None:
-    self._require_status_any2(UInt64(STATUS_RESOLVED), UInt64(STATUS_CANCELLED))
-    amount = self.dispute_sink_balance.value
-    self._require(amount > UInt64(0))
-    self.dispute_sink_balance.value = UInt64(0)
-    self._send_currency(Account(self.protocol_treasury.value), amount)
-    arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(amount))
+@subroutine
+def _entry_weighted_sum_checked(self, shares: UInt64, timestamp: UInt64) -> UInt64:
+    high, low = op.mulw(shares, timestamp)
+    self._require(high == UInt64(0))  # reverts on overflow
+    return low
 ```
 
-Alternatively, fold the sink share into `protocol_fee_balance` during settlement so it is withdrawn via the existing `withdraw_protocol_fees()` path.
+This function is called transitively from `claim_lp_residual`:
+
+```
+claim_lp_residual()
+  → _claimable_residual()
+    → _total_residual_weight()
+      → _calculate_weight(lp_shares_total, total_lp_weighted_entry_sum)
+        → _entry_weighted_sum_checked(lp_shares_total, settlement_timestamp - 1)
+```
+
+When `lp_shares_total × (settlement_timestamp − 1) > 2⁶⁴`, the `mulw` high word is nonzero and the assert fires, reverting the entire call. Because `_total_residual_weight` is shared by every LP's residual claim, **no LP can call `claim_lp_residual`** once the threshold is breached.
+
+### Threshold
+
+```
+UInt64 max:   18,446,744,073,709,551,615
+Timestamp:    ~1,777,708,800 (mid-2026)
+Max safe LP:  18,446,744,073,709,551,615 ÷ 1,777,708,800 ≈ 10,376,696,157
+
+In USDC (6 decimals): ~$10,376
+```
+
+The threshold decreases as Unix timestamps grow:
+
+| Year | Max safe total LP (USDC) |
+|------|--------------------------|
+| 2024 | $10,825 |
+| 2026 | $10,376 |
+| 2030 | $9,742 |
+| 2040 | $8,350 |
+
+### Impact
+
+LP residual is permanently locked. The overflow triggers whenever `lp_shares_total` exceeds the threshold — either from a single large bootstrap or accumulated `enter_lp_active` entries.
+
+Other claiming paths (`claim`, `refund`, `withdraw_lp_fees`) use separate code and are unaffected.
+
+### PoC
+
+`tests/test_poc_residual_overflow.py` — 5 passing tests demonstrating:
+
+- Exact threshold calculation (test_overflow_threshold_math)
+- Single $11,000 bootstrap triggers overflow with model verification (test_single_large_bootstrap_triggers_overflow)
+- Arithmetic proof that 6 × $2,000 LP entries accumulate past threshold (test_multiple_lps_accumulate_past_threshold)
+- Counter-example below threshold works correctly (test_safe_market_below_threshold)
+- Threshold decreasing over time (test_threshold_decreases_over_time)
+
+```bash
+PYTHONPATH=. .venv/bin/python -m pytest tests/test_poc_residual_overflow.py -v
+# 5 passed
+```
+
+Note: The Python reference model uses arbitrary-precision integers and doesn't overflow. The PoC proves the on-chain multiplication would exceed `UInt64` by checking the product against `2⁶⁴ − 1`.
+
+### Secondary concern
+
+The addition in `enter_lp_active` (L1110–1112) is also unchecked:
+
+```python
+self.total_lp_weighted_entry_sum.value = (
+    self.total_lp_weighted_entry_sum.value +
+    self._entry_weighted_sum_checked(delta_b, self._now())
+)
+```
+
+Individual `delta_b × now` products are overflow-checked, but the running total addition uses native `+`, which wraps on UInt64 overflow in AVM. Many small LP entries could silently wrap the total, corrupting residual weight calculations.
+
+### Suggested Fix
+
+Use 128-bit intermediates via `mulw` / `divmodw` throughout `_calculate_weight`, consistent with how `lmsr_mul_div_floor` already handles wide arithmetic elsewhere in the codebase.
+
+---
+
+## Finding 2: Missing Inventory Coverage Invariant
+
+### Severity: Low (defense-in-depth)
+
+### Vulnerability Detail
+
+The reference model (`model.py`) enforces `q[i] >= total_user_shares[i]` — an invariant asserting that the LMSR quantity vector always covers all issued user shares. The on-chain contract's `_assert_invariants()` (L631–666) checks solvency (`pool >= tcb`) and price-sum validity but does **not** include this inventory coverage check.
+
+### Impact
+
+If a bug in `buy`/`sell`/`claim`/`refund` were to desynchronize `q[i]` and `total_user_shares[i]`, it would go undetected on-chain. Currently all paths maintain the invariant correctly, so this is a defense-in-depth gap rather than an exploitable vulnerability.
+
+### Suggested Fix
+
+Add the check to `_assert_invariants`:
+
+```python
+for i in urange(self.num_outcomes.value):
+    self._require(self._get_quantity(i) >= self._get_total_user_shares(i))
+```
+
+This may conflict with the 4-page program-size constraint — if so, consider adding it only to `buy` and `sell` endpoints.

--- a/tests/test_poc_residual_overflow.py
+++ b/tests/test_poc_residual_overflow.py
@@ -1,0 +1,271 @@
+"""
+PoC: UInt64 Overflow in LP Residual Weight Calculation
+======================================================
+
+Vulnerability: _entry_weighted_sum_checked(lp_shares_total, settlement_timestamp - 1)
+overflows UInt64 when lp_shares_total * settlement_timestamp > 2^64.
+
+This permanently bricks claim_lp_residual() for ALL LP providers,
+locking their residual funds in the contract forever.
+
+Trigger condition (2026 timestamps):
+  lp_shares_total > 10,376,696,157  (~$10,376 USDC with 6 decimals)
+
+Affected code: contract.py L547-563 (_calculate_weight)
+               contract.py L570-571 (_total_residual_weight)
+               contract.py L574-584 (_claimable_residual)
+               contract.py L718-729 (claim_lp_residual)
+
+Reporter: y4motion
+"""
+from __future__ import annotations
+
+import math
+import pytest
+
+from smart_contracts.market_app.active_lp_model import ActiveLpMarketAppModel
+
+SCALE = 1_000_000_000
+
+def _py_lmsr_prices(q: list[int], b: int) -> list[int]:
+    """Pure Python LMSR price calculation (no AVM types)."""
+    max_q = max(q)
+    exps = [math.exp((qi - max_q) / b) for qi in q]
+    total = sum(exps)
+    return [int(SCALE * e / total) for e in exps]
+
+UINT64_MAX = 2**64 - 1
+
+
+def _make_large_lp_market(
+    *,
+    initial_b: int = 11_000_000_000,  # ~$11,000 USDC (above overflow threshold)
+    num_outcomes: int = 2,
+    deadline: int = 1_777_800_000,     # ~2026-06-02 timestamp
+    bootstrap_time: int = 1_777_700_000,  # activation timestamp
+) -> ActiveLpMarketAppModel:
+    """Create a market with b > overflow threshold for 2026 timestamps."""
+    return ActiveLpMarketAppModel(
+        creator="creator",
+        currency_asa=31566704,
+        outcome_asa_ids=[1000 + i for i in range(num_outcomes)],
+        b=initial_b,
+        lp_fee_bps=200,
+        protocol_fee_bps=50,
+        deadline=deadline,
+        question_hash=b"q" * 32,
+        main_blueprint_hash=b"b" * 32,
+        dispute_blueprint_hash=b"d" * 32,
+        challenge_window_secs=86_400,
+        protocol_config_id=77,
+        factory_id=88,
+        resolution_authority="resolver",
+        challenge_bond=10_000_000,
+        proposal_bond=10_000_000,
+        proposer_fee_bps=0,
+        proposer_fee_floor_bps=0,
+        grace_period_secs=3_600,
+        market_admin="admin",
+    )
+
+
+class TestResidualOverflowPoC:
+    """
+    Demonstrates that the UInt64 overflow in _entry_weighted_sum_checked
+    would permanently lock LP residual funds on-chain.
+
+    The Python reference model uses arbitrary-precision integers, so it
+    does NOT overflow. These tests prove the ON-CHAIN contract would revert
+    by checking the intermediate multiplication against UInt64 max.
+    """
+
+    def test_overflow_threshold_math(self) -> None:
+        """Verify the overflow threshold calculation."""
+        # Unix timestamp for mid-2026
+        timestamp = 1_777_800_000
+        max_safe_shares = UINT64_MAX // timestamp
+
+        # Any market with lp_shares_total > max_safe_shares will overflow
+        assert 10_376_000_000 < max_safe_shares < 10_377_000_000  # ~$10,376 USDC
+
+        # Demonstrate overflow for $11,000 market
+        lp_shares_total = 11_000_000_000
+        product = lp_shares_total * timestamp
+        assert product > UINT64_MAX, (
+            f"Product {product:,} should exceed UInt64 max {UINT64_MAX:,}"
+        )
+
+    def test_single_large_bootstrap_triggers_overflow(self) -> None:
+        """
+        A single bootstrap with b=$11,000 USDC creates lp_shares_total
+        that overflows in _total_residual_weight at claim time.
+
+        ON-CHAIN: claim_lp_residual() would REVERT at _entry_weighted_sum_checked
+        PYTHON MODEL: succeeds because Python integers don't overflow
+        """
+        market = _make_large_lp_market(initial_b=11_000_000_000)
+        bootstrap_time = 1_777_700_000
+
+        market.bootstrap(sender="creator", deposit_amount=11_000_000_000, now=bootstrap_time)
+
+        # A trader buys to create some pool surplus
+        market.buy(
+            sender="trader",
+            outcome_index=0,
+            shares=1_000_000,
+            max_cost=1_000_000_000,
+            now=bootstrap_time + 1000,
+        )
+
+        # Resolve the market
+        market.trigger_resolution(sender="anyone", now=market.deadline)
+        market.propose_resolution(
+            sender="resolver",
+            outcome_index=0,
+            evidence_hash=b"e" * 32,
+            now=market.deadline + 1,
+        )
+        market.finalize_resolution(
+            sender="anyone",
+            now=market.deadline + 1 + market.challenge_window_secs,
+        )
+
+        # In the Python model, this succeeds (arbitrary precision integers)
+        # On-chain, this would REVERT due to UInt64 overflow
+        settlement_ts = market.settlement_timestamp
+        lp_shares_total = market.lp_shares_total
+
+        # PROVE THE OVERFLOW: The on-chain multiplication would exceed UInt64
+        product = lp_shares_total * (settlement_ts - 1)
+        assert product > UINT64_MAX, (
+            f"CRITICAL: lp_shares_total({lp_shares_total:,}) * "
+            f"(settlement_ts-1)({settlement_ts - 1:,}) = {product:,} "
+            f"> UInt64_MAX({UINT64_MAX:,}). "
+            f"On-chain claim_lp_residual() would REVERT here!"
+        )
+
+        # The model still works (no overflow in Python)
+        residual = market.claim_lp_residual(sender="creator")
+        assert residual > 0, "Model claims residual fine, but on-chain would REVERT"
+
+        # Print diagnostic
+        print(f"\n{'='*70}")
+        print(f"  PoC: UInt64 Overflow in LP Residual Weight")
+        print(f"{'='*70}")
+        print(f"  lp_shares_total:     {lp_shares_total:>25,}")
+        print(f"  settlement_timestamp:{settlement_ts:>25,}")
+        print(f"  Product:             {product:>25,}")
+        print(f"  UInt64 MAX:          {UINT64_MAX:>25,}")
+        print(f"  Overflow by:         {product - UINT64_MAX:>25,}")
+        print(f"  Residual (model):    {residual:>25,}")
+        print(f"  On-chain result:     {'REVERT (permanently locked)':>25}")
+        print(f"{'='*70}")
+
+    def test_multiple_lps_accumulate_past_threshold(self) -> None:
+        """
+        Arithmetic proof: multiple smaller LP entries that individually
+        don't overflow, but accumulate lp_shares_total past the threshold.
+
+        NOTE: The full model-based repro requires on-chain localnet.
+        This test proves the overflow MATH is valid.
+        """
+        timestamp = 1_777_886_401  # Realistic 2026 settlement
+
+        # 6 LPs × $2,000 each = $12,000 total
+        per_lp_b = 2_000_000_000  # $2,000 USDC (6 decimals)
+        num_lps = 6
+        total_lp_shares = per_lp_b * num_lps  # 12,000,000,000
+
+        # Each individual LP is safe
+        individual_product = per_lp_b * timestamp
+        assert individual_product <= UINT64_MAX, "Individual LP entry should not overflow"
+
+        # But the accumulated total overflows
+        total_product = total_lp_shares * (timestamp - 1)
+        assert total_product > UINT64_MAX, (
+            f"6 LPs × $2,000 = $12,000 total. "
+            f"Product {total_product:,} > UInt64_MAX. "
+            f"ALL 6 LPs' residual is permanently locked on-chain."
+        )
+
+        print(f"\n{'='*70}")
+        print(f"  PoC: Multiple LPs Accumulate Past Overflow Threshold")
+        print(f"{'='*70}")
+        print(f"  Number of LPs:       {num_lps}")
+        print(f"  Per-LP contribution:  ${per_lp_b / 1_000_000:,.0f} USDC")
+        print(f"  Total LP shares:     {total_lp_shares:>25,}")
+        print(f"  settlement_timestamp:{timestamp:>25,}")
+        print(f"  Individual product:  {individual_product:>25,} (safe)")
+        print(f"  Total product:       {total_product:>25,} (OVERFLOW!)")
+        print(f"  UInt64 MAX:          {UINT64_MAX:>25,}")
+        print(f"  Overflow by:         {total_product - UINT64_MAX:>25,}")
+        print(f"  On-chain result:     ALL {num_lps} LPs' residual PERMANENTLY LOCKED")
+        print(f"{'='*70}")
+
+    def test_safe_market_below_threshold(self) -> None:
+        """Counter-example: a market below the threshold works correctly."""
+        safe_b = 5_000_000_000  # $5,000 USDC (below threshold)
+        market = _make_large_lp_market(initial_b=safe_b)
+        bootstrap_time = 1_777_700_000
+
+        market.bootstrap(sender="creator", deposit_amount=safe_b, now=bootstrap_time)
+
+        market.buy(
+            sender="trader",
+            outcome_index=0,
+            shares=1_000_000,
+            max_cost=1_000_000_000,
+            now=bootstrap_time + 1000,
+        )
+
+        market.trigger_resolution(sender="anyone", now=market.deadline)
+        market.propose_resolution(
+            sender="resolver",
+            outcome_index=0,
+            evidence_hash=b"e" * 32,
+            now=market.deadline + 1,
+        )
+        market.finalize_resolution(
+            sender="anyone",
+            now=market.deadline + 1 + market.challenge_window_secs,
+        )
+
+        # Below threshold: no overflow
+        settlement_ts = market.settlement_timestamp
+        product = market.lp_shares_total * (settlement_ts - 1)
+        assert product <= UINT64_MAX, "Safe market should not overflow"
+
+        # Both model and on-chain would succeed
+        residual = market.claim_lp_residual(sender="creator")
+        assert residual > 0
+
+    def test_threshold_decreases_over_time(self) -> None:
+        """
+        The overflow threshold DECREASES as Unix timestamps grow.
+        Markets that were safe in 2024 may break in 2030+.
+        """
+        thresholds = {}
+        for year, ts in [
+            (2024, 1_704_067_200),
+            (2026, 1_777_708_800),
+            (2030, 1_893_456_000),
+            (2040, 2_208_988_800),
+            (2050, 2_524_608_000),
+        ]:
+            max_shares = UINT64_MAX // ts
+            thresholds[year] = max_shares / 1_000_000  # Convert to USDC
+
+        # Verify decreasing trend
+        years = sorted(thresholds.keys())
+        for i in range(len(years) - 1):
+            assert thresholds[years[i]] > thresholds[years[i + 1]], (
+                f"Threshold should decrease: {years[i]}=${thresholds[years[i]]:,.0f} "
+                f"vs {years[i+1]}=${thresholds[years[i+1]]:,.0f}"
+            )
+
+        print(f"\n{'='*70}")
+        print(f"  Time-Bomb: Overflow Threshold Decreases Over Time")
+        print(f"{'='*70}")
+        for year, threshold_usdc in sorted(thresholds.items()):
+            print(f"  {year}: Max safe total LP = ${threshold_usdc:>12,.2f} USDC")
+        print(f"{'='*70}")


### PR DESCRIPTION
## Bug Bounty Submission (Issue #13)

Two issues found during manual review of `market_app/contract.py`:

### Finding 1: UInt64 Overflow in LP Residual Weight (Medium)

`_entry_weighted_sum_checked` (L587–590) computes `shares × timestamp` with a `mulw` overflow guard. When called from `_total_residual_weight()` with `lp_shares_total × (settlement_timestamp − 1) > 2⁶⁴`, the assert fires and **permanently blocks `claim_lp_residual()` for all LPs**.

**Threshold (2026):** ~$10,376 USDC total LP contribution
**Impact:** LP residual permanently locked — no LP can claim
**Trend:** Threshold decreases over time (~$9,742 by 2030, ~$8,350 by 2040)

Call chain:
```
claim_lp_residual → _claimable_residual → _total_residual_weight
  → _calculate_weight → _entry_weighted_sum_checked(lp_shares_total, settlement_ts-1)
  → op.mulw OVERFLOW → REVERT
```

Secondary: the `total_lp_weighted_entry_sum` addition (L1110–1112) uses native `+` which wraps silently on UInt64 overflow in AVM, potentially corrupting weight calculations when many small LP entries accumulate.

**Fix:** Use 128-bit intermediates via `mulw`/`divmodw` in `_calculate_weight`, consistent with how `lmsr_mul_div_floor` already handles wide arithmetic.

### Finding 2: Missing Inventory Coverage Invariant (Low)

The reference model asserts `q[i] >= total_user_shares[i]` but the on-chain `_assert_invariants()` (L631–666) omits this check. Defense-in-depth gap.

### PoC

5 passing tests in `tests/test_poc_residual_overflow.py`:
```bash
PYTHONPATH=. .venv/bin/python -m pytest tests/test_poc_residual_overflow.py -v
# 5 passed
```

Full details in `VULNERABILITY_REPORT.md`.

closes #13 