### PR TITLE
Add withdraw_dispute_sink method

### DIFF
--- a/scripts/repro.sh
+++ b/scripts/repro.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Reproduction script for withdraw_dispute_sink issue
+# This script sets up a local Ethereum testnet using Anvil (Foundry) and runs a simple deployment
+# Adjust paths and parameters as needed for the project.
+
+if ! command -v anvil >/dev/null 2>&1; then
+  echo "Anvil (Foundry) not found. Install Foundry: curl -L https://foundry.paradigm.xyz | bash && source ~/.bashrc && foundryup"
+  exit 1
+fi
+
+# Start local Anvil node
+anvil -p 8545 &
+ANVIL_PID=$!
+trap "kill $ANVIL_PID" EXIT
+
+# Wait a moment for node to be ready
+sleep 2
+
+# Deploy contracts (example command, adjust to actual deployment script)
+# forge script script/Deploy.s.sol:Deploy --fork-url http://127.0.0.1:8545 --broadcast
+
+echo "Replace the above command with the actual deployment script for this repository."

--- a/smart_contracts/market_app/contract.py
+++ b/smart_contracts/market_app/contract.py
@@ -1384,6 +1384,21 @@ class QuestionMarket(ARC4Contract):
         arc4.emit("WithdrawFees(uint64)", arc4.UInt64(amount))
 
     @arc4.abimethod()
+    @arc4.abimethod()
+    def withdraw_dispute_sink(self, amount: arc4.UInt64) -> None:
+        """Withdraw a specified amount of USDC from the dispute sink.
+
+        The dispute sink holds slashed bond funds that would otherwise be
+        permanently locked. This method allows the protocol treasury (or an
+        authorized admin) to recover those funds.
+        """
+        withdraw_amount = amount.as_uint64()
+        self._require(withdraw_amount > UInt64(0))
+        self._require(self.dispute_sink_balance.value >= withdraw_amount)
+        self.dispute_sink_balance.value = self.dispute_sink_balance.value - withdraw_amount
+        self._send_currency(Account(self.protocol_treasury.value), withdraw_amount)
+        arc4.emit("WithdrawDisputeSink(uint64)", arc4.UInt64(withdraw_amount))
+
     def refund(self, outcome_index: arc4.UInt64, shares: arc4.UInt64) -> None:
         self._require_status(UInt64(STATUS_CANCELLED))
         outcome = outcome_index.as_uint64()


### PR DESCRIPTION
This PR adds the `withdraw_dispute_sink` method to enable protocol treasury to withdraw funds from the dispute sink.